### PR TITLE
Copy pywin32 "system" libraries to Python's root directory

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,8 +18,6 @@ build:
     - python setup.py install --record=record.txt  # [not py3k]
     - python setup3.py install --record=record.txt  # [py3k]
     - copy %PREFIX%\Lib\site-packages\pywin32_system32\*.dll %PREFIX%
-    - dir %PREFIX%\pythoncom%CONDA_PY%.dll
-    - dir %PREFIX%\pywintypes%CONDA_PY%.dll
 
   skip: True  # [not win]
 
@@ -28,6 +26,11 @@ requirements:
     - python 
   run:
     - python
+
+test:
+  commands:
+    - dir %PREFIX%\pythoncom%CONDA_PY%.dll
+    - dir %PREFIX%\pywintypes%CONDA_PY%.dll
 
 about:
   home: https://sourceforge.net/projects/pywin32

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,8 +29,8 @@ requirements:
 
 test:
   commands:
-    - dir %PREFIX%\pythoncom%CONDA_PY%.dll
-    - dir %PREFIX%\pywintypes%CONDA_PY%.dll
+    - if not exist %PREFIX%\pythoncom%CONDA_PY%.dll exit 1
+    - if not exist %PREFIX%\pywintypes%CONDA_PY%.dll exit 1
 
 about:
   home: https://sourceforge.net/projects/pywin32

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,8 @@ build:
     - python setup.py install --record=record.txt  # [not py3k]
     - python setup3.py install --record=record.txt  # [py3k]
     - copy %PREFIX%\Lib\site-packages\pywin32_system32\*.dll %PREFIX%
-    - dir pywintypes%CONDA_PY%.dll
+    - dir %PREFIX%\pythoncom%CONDA_PY%.dll
+    - dir %PREFIX%\pywintypes%CONDA_PY%.dll
 
   skip: True  # [not win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,10 +13,13 @@ source:
   {{ hash_type }}: {{ hash }}
 
 build:
-  number: 0
+  number: 1
   script: 
     - python setup.py install --record=record.txt  # [not py3k]
     - python setup3.py install --record=record.txt  # [py3k]
+    - copy %PREFIX%\Lib\site-packages\pywin32_system32\*.dll %PREFIX%
+    - dir pywintypes%CONDA_PY%.dll
+
   skip: True  # [not win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
   script: 
     - python setup.py install --record=record.txt  # [not py3k]
     - python setup3.py install --record=record.txt  # [py3k]
-    - copy %PREFIX%\Lib\site-packages\pywin32_system32\*.dll %PREFIX%
+    - copy %PREFIX%\Lib\site-packages\pywin32_system32\*.dll %LIBRARY_BIN%
 
   skip: True  # [not win]
 
@@ -29,8 +29,8 @@ requirements:
 
 test:
   commands:
-    - if not exist %PREFIX%\pythoncom%CONDA_PY%.dll exit 1
-    - if not exist %PREFIX%\pywintypes%CONDA_PY%.dll exit 1
+    - if not exist %LIBRARY_BIN%\pythoncom%CONDA_PY%.dll exit 1
+    - if not exist %LIBRARY_BIN%\pywintypes%CONDA_PY%.dll exit 1
 
 about:
   home: https://sourceforge.net/projects/pywin32


### PR DESCRIPTION
As #1 and #2 show, this must be done manually otherwise pywintypes will fail
during import on systems where the standard Python installation was not used,
which is exactly the case when installing Python using conda